### PR TITLE
Implement sniffs to allow psr2-r multiline rules

### DIFF
--- a/code-sniffer/Vanilla/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Parses and verifies the doc comments for classes.
+ * Based on Squiz_Sniffs_Arrays_ArrayDeclarationSniff
+ *
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+
+/**
+ * A test to ensure that arrays conform to the array coding standard.
+ */
+class Vanilla_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sniff {
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register() {
+        return array(
+            T_ARRAY,
+            T_OPEN_SHORT_ARRAY,
+        );
+
+    }//end register()
+
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The current file being checked.
+     * @param int $stackPtr The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === T_ARRAY) {
+            $phpcsFile->recordMetric($stackPtr, 'Short array syntax used', 'no');
+
+            $arrayStart = $tokens[$stackPtr]['parenthesis_opener'];
+            if (isset($tokens[$arrayStart]['parenthesis_closer']) === false) {
+                return;
+            }
+
+            $arrayEnd = $tokens[$arrayStart]['parenthesis_closer'];
+        } else {
+            $phpcsFile->recordMetric($stackPtr, 'Short array syntax used', 'yes');
+            $arrayStart = $stackPtr;
+            $arrayEnd = $tokens[$stackPtr]['bracket_closer'];
+        }
+
+        if ($tokens[$arrayStart]['line'] === $tokens[$arrayEnd]['line']) {
+            $this->processSingleLineArray($phpcsFile, $stackPtr, $arrayStart, $arrayEnd);
+        }
+
+    }//end process()
+
+
+    /**
+     * Processes a single-line array definition.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The current file being checked.
+     * @param int $stackPtr The position of the current token
+     *                                         in the stack passed in $tokens.
+     * @param int $arrayStart The token that starts the array definition.
+     * @param int $arrayEnd The token that ends the array definition.
+     *
+     * @return void
+     */
+    public function processSingleLineArray(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $arrayStart, $arrayEnd) {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check if there are multiple values. If so, then it has to be multiple lines
+        // unless it is contained inside a function call or condition.
+        for ($i = ($arrayStart + 1); $i < $arrayEnd; $i++) {
+            // Skip bracketed statements, like function calls.
+            if ($tokens[$i]['code'] === T_OPEN_PARENTHESIS) {
+                $i = $tokens[$i]['parenthesis_closer'];
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === T_COMMA) {
+                // Before counting this comma, make sure we are not
+                // at the end of the array.
+                $next = $phpcsFile->findNext(T_WHITESPACE, ($i + 1), $arrayEnd, true);
+                if ($next === false) {
+                    // There is a comma at the end of a single line array.
+                    $error = 'Comma not allowed after last value in single-line array declaration';
+                    $fix = $phpcsFile->addFixableError($error, $i, 'CommaAfterLast');
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+                }
+            }
+        }//end for
+    }
+}

--- a/code-sniffer/Vanilla/Sniffs/Methods/MethodCallFormattingSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Methods/MethodCallFormattingSniff.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Verifies method calls formatting.
+
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+/**
+ * Class Vanilla_Sniffs_Methods_MethodCallSniff
+ */
+class Vanilla_Sniffs_Methods_MethodCallFormattingSniff implements PHP_CodeSniffer_Sniff {
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register() {
+        return [T_VARIABLE];
+    }
+
+
+    /**
+     * @param PHP_CodeSniffer_File $phpcsFile
+     * @param int $stackPtr
+     * @return null
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+        $tokens = $phpcsFile->getTokens();
+
+        $pointer = $stackPtr + 1;
+        $this->moveToNextNonWhitespace($tokens, $pointer);
+        $objectCalls = $this->getObjectFunctionCalls($tokens, $pointer);
+
+        // Check that the semicolon is right after the method call if they are no chaining
+        if ($objectCalls['calls']
+            && !$objectCalls['hasChaining']
+            && $tokens[$pointer]['code'] === T_SEMICOLON
+            && $tokens[$pointer-1]['code'] === T_WHITESPACE) {
+
+            $error = 'Semicolon must be at the end of the function when not chaining calls.';
+            $phpcsFile->addError($error, $pointer, 'SemicolonWhiteSpace');
+        }
+    }
+
+    /**
+     * Get the function calls (can be multiple if chained) on an object.
+     *
+     * @param array $tokens
+     * @param $pointer
+     * @return array
+     */
+    private function getObjectFunctionCalls(array $tokens, &$pointer) {
+        $chainedCalls = [
+            'hasChaining' => false,
+            'calls' => [],
+        ];
+        while ($tokens[$pointer]['code'] === T_OBJECT_OPERATOR) {
+            $tmpToken = $tokens[++$pointer];
+            $pointer++; // Next token;
+            $this->moveToNextNonWhitespace($tokens, $pointer);
+            $tmpTokenType = $this->getTokenType($tokens[$pointer]);
+
+            $chainedCalls['calls'] = [
+                'token' => $tmpToken,
+                'type' => $tmpTokenType,
+            ];
+
+            $lineFeedDetected = $this->movePointerToNextObject($tokens, $pointer);
+            if ($tokens[$pointer]['code'] === T_SEMICOLON) {
+                break;
+            }
+
+            if ($chainedCalls['hasChaining'] === false && $lineFeedDetected) {
+                $chainedCalls['hasChaining'] = true;
+            }
+        }
+        return $chainedCalls;
+    }
+
+    /**
+     * Return the current token type.
+     *
+     * @param array $token
+     *
+     * @return string
+     */
+    private function getTokenType($token) {
+        if ($token['code'] === T_OPEN_PARENTHESIS) {
+            return 'method';
+        }
+        return 'property';
+    }
+
+    /**
+     * Move the pointer to the next non whitespace token.
+     *
+     * @param array $tokens
+     * @param int $pointer
+     * @return bool true if a line feed was detected, false otherwise.
+     */
+    private function moveToNextNonWhitespace(array $tokens, &$pointer) {
+        $hasLineFeed = false;
+        while ($tokens[$pointer]['code'] === T_WHITESPACE) {
+            if (!$hasLineFeed) {
+                $hasLineFeed = strpos($tokens[$pointer]['content'], "\n") !== false;
+            }
+            ++$pointer;
+        }
+        return $hasLineFeed;
+    }
+
+    /**
+     * Move the pointer to the next object.
+     *
+     * @param array $tokens
+     * @param int $pointer
+     *
+     * @return bool true if a line feed was detected, false otherwise.
+     */
+    private function movePointerToNextObject(array $tokens, &$pointer) {
+        $token = $tokens[$pointer];
+        // Ignore "(" ... ")" in a method call by moving pointer after close parenthesis token
+        if ($token['code'] === T_OPEN_PARENTHESIS) {
+            $pointer = $token['parenthesis_closer'] + 1;
+        }
+        return $this->moveToNextNonWhitespace($tokens, $pointer);
+    }
+
+}
+?>


### PR DESCRIPTION
- Check that single line array declarations ends with no comma.
- Check that non multiline function/property calls on an object has the semicolon ending on the same line.

Fixes https://github.com/vanilla/standards/issues/3

Test file!
```php
<?php
/**
 * Filedoc.
 *
 * @copyright 2009-2017 Vanilla Forums Inc.
 */

// Good
$obs->call1();

// Fail 
$obs->subObject->call1()
;

// Good
$obs->subObject
    ->call1()
    ->subOject
;

// Good
$obs->call1()->call1()->call1()
->call2()
->call1()
;

// Fail
$obs->call1()->call2()
;

// Good
$obs->call1()
    ->call2()
;

// Good
$obs->call1()
    ->call2()
    ->call3();

// Good
$arr = [
    1,
    3,
    4,
];

// Good
$arr = [
    1,
    3,
    4
];

// Fail
$arr = [1, 3, 4,];
```