### PR TITLE
Enforce 1 space in DocBlock after type and name

### DIFF
--- a/code-sniffer/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -429,7 +429,7 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
             $foundParams[] = $param['var'];
 
             // Check number of spaces after the type.
-            $spaces = ($maxType - strlen($param['type']) + 1);
+            $spaces = 1;
             if ($param['type_space'] !== $spaces) {
                 $error = 'Expected %s spaces after parameter type; %s found';
                 $data  = array(
@@ -479,7 +479,7 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
             }
 
             // Check number of spaces after the var name.
-            $spaces = ($maxVar - strlen($param['var']) + 1);
+            $spaces = 1;
             if ($param['var_space'] !== $spaces) {
                 $error = 'Expected %s spaces after parameter name; %s found';
                 $data  = array(
@@ -511,6 +511,5 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
             $data  = array($neededParam);
             $phpcsFile->addError($error, $commentStart, 'MissingParamTag', $data);
         }
-
     }
 }


### PR DESCRIPTION
This PR solves [this issue](https://github.com/vanilla/standards/issues/8). By an example of Gdn_Model, this is how **code**  looks by now:

~~~
     * @param array|false $where The where clause.
     * @param array $options An array of option keys to default values.
~~~

The current standard would require it to look like that:
~~~
     * @param array|false $where   The where clause.
     * @param array       $options An array of option keys to default values.
~~~

That is obviously not what you can find throughout Vanillas code base and therefore it should e changed to prevent false positives when checking for code formatting