### PR TITLE
Improve compatibility with PHP_CodeSniffer v3

### DIFF
--- a/code-sniffer/Vanilla/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -7,11 +7,13 @@
  * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
  */
 
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
 
 /**
  * A test to ensure that arrays conform to the array coding standard.
  */
-class Vanilla_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sniff {
+class Vanilla_Sniffs_Arrays_ArrayDeclarationSniff implements Sniff {
 
 
     /**
@@ -31,13 +33,13 @@ class Vanilla_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sni
     /**
      * Processes this sniff, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The current file being checked.
+     * @param File $phpcsFile The current file being checked.
      * @param int $stackPtr The position of the current token in
      *                                        the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+    public function process(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
 
         if ($tokens[$stackPtr]['code'] === T_ARRAY) {
@@ -65,15 +67,14 @@ class Vanilla_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sni
     /**
      * Processes a single-line array definition.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The current file being checked.
-     * @param int $stackPtr The position of the current token
-     *                                         in the stack passed in $tokens.
+     * @param File $phpcsFile The current file being checked.
+     * @param int $stackPtr The position of the current token in the stack passed in $tokens.
      * @param int $arrayStart The token that starts the array definition.
      * @param int $arrayEnd The token that ends the array definition.
      *
      * @return void
      */
-    public function processSingleLineArray(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $arrayStart, $arrayEnd) {
+    public function processSingleLineArray(File $phpcsFile, $stackPtr, $arrayStart, $arrayEnd) {
         $tokens = $phpcsFile->getTokens();
 
         // Check if there are multiple values. If so, then it has to be multiple lines

--- a/code-sniffer/Vanilla/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -12,9 +12,10 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-if (class_exists('PHP_CodeSniffer_Standards_AbstractVariableSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractVariableSniff not found');
-}
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Verifies that properties are declared correctly.
@@ -27,24 +28,24 @@ if (class_exists('PHP_CodeSniffer_Standards_AbstractVariableSniff', true) === fa
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Vanilla_Sniffs_Classes_PropertyDeclarationSniff extends PHP_CodeSniffer_Standards_AbstractVariableSniff
+class Vanilla_Sniffs_Classes_PropertyDeclarationSniff extends AbstractVariableSniff
 {
 
 
     /**
      * Processes the function tokens within the class.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file where this token was found.
-     * @param int                  $stackPtr  The position where the token was found.
+     * @param File $phpcsFile The file where this token was found.
+     * @param int $stackPtr  The position where the token was found.
      *
      * @return void
      */
-    protected function processMemberVar(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+    protected function processMemberVar(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
 
         $propertyName = ltrim($tokens[$stackPtr]['content'][1], '$');
 
-        if (PHP_CodeSniffer::isCamelCaps($propertyName, false, true, false) === false) {
+        if (Common::isCamelCaps($propertyName, false, true, false) === false) {
             $error = 'Property name "%s" should be camelCase';
             $data  = array($tokens[$stackPtr]['content']);
             $phpcsFile->addWarning($error, $stackPtr, 'Underscore', $data);
@@ -59,7 +60,7 @@ class Vanilla_Sniffs_Classes_PropertyDeclarationSniff extends PHP_CodeSniffer_St
         // Detect multiple properties defined at the same time. Throw an error
         // for this, but also only process the first property in the list so we don't
         // repeat errors.
-        $find = PHP_CodeSniffer_Tokens::$scopeModifiers;
+        $find = Tokens::$scopeModifiers;
         $find = array_merge($find, array(T_VARIABLE, T_VAR, T_SEMICOLON));
         $prev = $phpcsFile->findPrevious($find, ($stackPtr - 1));
         if ($tokens[$prev]['code'] === T_VARIABLE) {
@@ -77,7 +78,7 @@ class Vanilla_Sniffs_Classes_PropertyDeclarationSniff extends PHP_CodeSniffer_St
             $phpcsFile->addError($error, $stackPtr, 'Multiple');
         }
 
-        $modifier = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$scopeModifiers, $stackPtr);
+        $modifier = $phpcsFile->findPrevious(Tokens::$scopeModifiers, $stackPtr);
         if (($modifier === false) || ($tokens[$modifier]['line'] !== $tokens[$stackPtr]['line'])) {
             $error = 'Visibility must be declared on property "%s"';
             $data  = array($tokens[$stackPtr]['content']);
@@ -90,12 +91,12 @@ class Vanilla_Sniffs_Classes_PropertyDeclarationSniff extends PHP_CodeSniffer_St
     /**
      * Processes normal variables.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file where this token was found.
-     * @param int                  $stackPtr  The position where the token was found.
+     * @param File $phpcsFile The file where this token was found.
+     * @param int $stackPtr  The position where the token was found.
      *
      * @return void
      */
-    protected function processVariable(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+    protected function processVariable(File $phpcsFile, $stackPtr) {
         // We don't care about normal variables.
 
     }//end processVariable()
@@ -104,12 +105,12 @@ class Vanilla_Sniffs_Classes_PropertyDeclarationSniff extends PHP_CodeSniffer_St
     /**
      * Processes variables in double quoted strings.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file where this token was found.
-     * @param int                  $stackPtr  The position where the token was found.
+     * @param File $phpcsFile The file where this token was found.
+     * @param int $stackPtr  The position where the token was found.
      *
      * @return void
      */
-    protected function processVariableInString(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+    protected function processVariableInString(File $phpcsFile, $stackPtr) {
         // We don't care about normal variables.
 
     }//end processVariableInString()

--- a/code-sniffer/Vanilla/Sniffs/Classes/ValidClassNameSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Classes/ValidClassNameSniff.php
@@ -13,10 +13,14 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Common;
+
 /**
  * Ensures classes are in camel caps, and the first letter is capitalised or begin with "Gdn_".
  */
-class Vanilla_Sniffs_Classes_ValidClassNameSniff implements PHP_CodeSniffer_Sniff {
+class Vanilla_Sniffs_Classes_ValidClassNameSniff implements Sniff {
 
 
     /**
@@ -36,13 +40,13 @@ class Vanilla_Sniffs_Classes_ValidClassNameSniff implements PHP_CodeSniffer_Snif
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The current file being processed.
+     * @param File $phpcsFile The current file being processed.
      * @param int $stackPtr The position of the current token in the
      *                                        stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+    public function process(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
 
         if (isset($tokens[$stackPtr]['scope_opener']) === false) {
@@ -66,7 +70,7 @@ class Vanilla_Sniffs_Classes_ValidClassNameSniff implements PHP_CodeSniffer_Snif
         }
 
         // Check for camel caps format.
-        $valid = PHP_CodeSniffer::isCamelCaps($name, true, true, false);
+        $valid = Common::isCamelCaps($name, true, true, false);
         if ($valid === false) {
             $type = ucfirst($tokens[$stackPtr]['content']);
             $error = '%s name "%s" is not in camel caps format';

--- a/code-sniffer/Vanilla/Sniffs/Commenting/ClassCommentSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Commenting/ClassCommentSniff.php
@@ -6,6 +6,10 @@
  * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
  */
 
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
 /**
  * Parses and verifies the doc comments for classes.
  *
@@ -18,7 +22,7 @@
  *  <li>There is a blank line between the description and the tags.</li>
  * </ul>
  */
-class Vanilla_Sniffs_Commenting_ClassCommentSniff implements PHP_CodeSniffer_Sniff {
+class Vanilla_Sniffs_Commenting_ClassCommentSniff implements Sniff {
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -36,20 +40,19 @@ class Vanilla_Sniffs_Commenting_ClassCommentSniff implements PHP_CodeSniffer_Sni
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr  The position of the current token in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+    public function process(File $phpcsFile, $stackPtr) {
         $this->currentFile = $phpcsFile;
 
         $tokens    = $phpcsFile->getTokens();
         $type      = strtolower($tokens[$stackPtr]['content']);
         $errorData = array($type);
 
-        $find   = PHP_CodeSniffer_Tokens::$methodPrefixes;
+        $find   = Tokens::$methodPrefixes;
         $find[] = T_WHITESPACE;
 
         $empty = array(

--- a/code-sniffer/Vanilla/Sniffs/Commenting/FileCommentSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Commenting/FileCommentSniff.php
@@ -6,6 +6,9 @@
  * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
  */
 
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
  * Parses and verifies the doc comments for files.
  *
@@ -15,7 +18,7 @@
  *  <li>Check that license and copyright tags are presents.</li>
  * </ul>
  */
-class Vanilla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff {
+class Vanilla_Sniffs_Commenting_FileCommentSniff implements Sniff {
 
     /**
      * A list of tokenizers this sniff supports.
@@ -28,16 +31,9 @@ class Vanilla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Snif
     );
 
     /**
-     * The header comment parser for the current file.
-     *
-     * @var PHP_CodeSniffer_Comment_Parser_ClassCommentParser
-     */
-    protected $commentParser = null;
-
-    /**
      * The current PHP_CodeSniffer_File object we are processing.
      *
-     * @var PHP_CodeSniffer_File
+     * @var File
      */
     protected $currentFile = null;
 
@@ -71,13 +67,12 @@ class Vanilla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Snif
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr  The position of the current token in the stack passed in $tokens.
      *
      * @return int
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+    public function process(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
 
         $empty = array(
@@ -140,14 +135,13 @@ class Vanilla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Snif
     /**
      * Processes each required or optional tag.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token
-     *                                           in the stack passed in $tokens.
-     * @param int                  $commentStart Position in the stack where the comment started.
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+     * @param int $commentStart Position in the stack where the comment started.
      *
      * @return void
      */
-    protected function processTags(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart) {
+    protected function processTags(File $phpcsFile, $stackPtr, $commentStart) {
         $tokens = $phpcsFile->getTokens();
 
         if (get_class($this) === 'PEAR_Sniffs_Commenting_FileCommentSniff') {
@@ -237,12 +231,12 @@ class Vanilla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Snif
     /**
      * Process the copyright tags.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param array                $tags      The tokens for these tags.
+     * @param File $phpcsFile The file being scanned.
+     * @param array $tags The tokens for these tags.
      *
      * @return void
      */
-    protected function processCopyright(PHP_CodeSniffer_File $phpcsFile, array $tags) {
+    protected function processCopyright(File $phpcsFile, array $tags) {
         $vanillaFound = false;
         $tokens = $phpcsFile->getTokens();
         foreach ($tags as $tag) {
@@ -276,12 +270,12 @@ class Vanilla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Snif
     /**
      * Process the license tag.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param array                $tags      The tokens for these tags.
+     * @param File $phpcsFile The file being scanned.
+     * @param array $tags The tokens for these tags.
      *
      * @return void
      */
-    protected function processLicense(PHP_CodeSniffer_File $phpcsFile, array $tags) {
+    protected function processLicense(File $phpcsFile, array $tags) {
         $tokens = $phpcsFile->getTokens();
         foreach ($tags as $tag) {
             if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {

--- a/code-sniffer/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -6,6 +6,10 @@
  * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
  */
 
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
 /**
  * Parses and verifies the doc comments for functions.
  *
@@ -23,7 +27,7 @@
  *  <li>The tag order and indentation are correct</li>
  * </ul>
  */
-class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sniff {
+class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements Sniff {
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -39,15 +43,14 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr  The position of the current token in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+    public function process(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
-        $find   = PHP_CodeSniffer_Tokens::$methodPrefixes;
+        $find   = Tokens::$methodPrefixes;
         $find[] = T_WHITESPACE;
 
         $empty = array(
@@ -222,14 +225,13 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
     /**
      * Process the return comment of this function comment.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token
-     *                                           in the stack passed in $tokens.
-     * @param int                  $commentStart The position in the stack where the comment started.
+     * @param File $phpcsFile    The file being scanned.
+     * @param int $stackPtr     The position of the current token in the stack passed in $tokens.
+     * @param int $commentStart The position in the stack where the comment started.
      *
      * @return void
      */
-    protected function processReturn(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart) {
+    protected function processReturn(File $phpcsFile, $stackPtr, $commentStart) {
         $tokens = $phpcsFile->getTokens();
 
         // Skip constructor and destructor.
@@ -270,14 +272,13 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
     /**
      * Process any throw tags that this function comment has.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token
-     *                                           in the stack passed in $tokens.
-     * @param int                  $commentStart The position in the stack where the comment started.
+     * @param File $phpcsFile    The file being scanned.
+     * @param int $stackPtr     The position of the current token in the stack passed in $tokens.
+     * @param int $commentStart The position in the stack where the comment started.
      *
      * @return void
      */
-    protected function processThrows(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart) {
+    protected function processThrows(File $phpcsFile, $stackPtr, $commentStart) {
         $tokens = $phpcsFile->getTokens();
 
         foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
@@ -335,14 +336,13 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
     /**
      * Process the function parameter comments.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token
-     *                                           in the stack passed in $tokens.
-     * @param int                  $commentStart The position in the stack where the comment started.
+     * @param File $phpcsFile    The file being scanned.
+     * @param int $stackPtr     The position of the current token in the stack passed in $tokens.
+     * @param int $commentStart The position in the stack where the comment started.
      *
      * @return void
      */
-    protected function processParams(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart) {
+    protected function processParams(File $phpcsFile, $stackPtr, $commentStart) {
         $tokens = $phpcsFile->getTokens();
 
         // Validate params structure

--- a/code-sniffer/Vanilla/Sniffs/Methods/CamelCapsMethodNameSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Methods/CamelCapsMethodNameSniff.php
@@ -12,9 +12,9 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-if (class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractScopeSniff not found');
-}
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Common;
 
 /**
  * PSR1_Sniffs_Methods_CamelCapsMethodNameSniff.
@@ -29,7 +29,7 @@ if (class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends PHP_CodeSniffer_Standards_AbstractScopeSniff
+class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends AbstractScopeSniff
 {
 
     protected $magicMethods = [
@@ -51,14 +51,13 @@ class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends PHP_CodeSniffer_St
     /**
      * Processes the tokens within the scope.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being processed.
-     * @param int                  $stackPtr  The position where this token was
-     *                                        found.
-     * @param int                  $currScope The position of the current scope.
+     * @param File $phpcsFile The file being processed.
+     * @param int $stackPtr  The position where this token was found.
+     * @param int $currScope The position of the current scope.
      *
      * @return void
      */
-    protected function processTokenWithinScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $currScope)
+    protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
     {
         $methodName = $phpcsFile->getDeclarationName($stackPtr);
         if ($methodName === null) {
@@ -81,7 +80,7 @@ class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends PHP_CodeSniffer_St
                 $phpcsFile->addError($error, $stackPtr, 'NotVanilla', $errorData);
             }
 
-        } elseif (!PHP_CodeSniffer::isCamelCaps($testName, false, true, false)) {
+        } elseif (!Common::isCamelCaps($testName, false, true, false)) {
             $error     = 'Method name "%s" is not in camel caps format';
             $className = $phpcsFile->getDeclarationName($currScope);
             $errorData = array($className.'::'.$methodName);
@@ -117,7 +116,7 @@ class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends PHP_CodeSniffer_St
 
         $parts = preg_split('/_/', $name);
         foreach ($parts as $part) {
-            if (PHP_CodeSniffer::isCamelCaps($part, false, true, false) === false) {
+            if (Common::isCamelCaps($part, false, true, false) === false) {
                 return false;
             }
         }
@@ -128,13 +127,12 @@ class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends PHP_CodeSniffer_St
     /**
      * Processes the tokens outside the scope.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being processed.
-     * @param int                  $stackPtr  The position where this token was
-     *                                        found.
+     * @param File $phpcsFile The file being processed.
+     * @param int $stackPtr  The position where this token was found.
      *
      * @return void
      */
-    protected function processTokenOutsideScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processTokenOutsideScope(File $phpcsFile, $stackPtr)
     {
         $functionName = $phpcsFile->getDeclarationName($stackPtr);
         if ($functionName === null) {
@@ -154,7 +152,7 @@ class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends PHP_CodeSniffer_St
             }
 
         } else {
-            if (PHP_CodeSniffer::isCamelCaps($functionName, false, true, false) === false) {
+            if (Common::isCamelCaps($functionName, false, true, false) === false) {
                 $error     = 'Function name "%s" is not in valid vanilla format';
                 $errorData = array($functionName);
                 $phpcsFile->addError($error, $stackPtr, 'globalFunctionNaming', $errorData);

--- a/code-sniffer/Vanilla/Sniffs/Methods/MethodCallFormattingSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Methods/MethodCallFormattingSniff.php
@@ -6,10 +6,13 @@
  * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
  */
 
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
  * Class Vanilla_Sniffs_Methods_MethodCallSniff
  */
-class Vanilla_Sniffs_Methods_MethodCallFormattingSniff implements PHP_CodeSniffer_Sniff {
+class Vanilla_Sniffs_Methods_MethodCallFormattingSniff implements Sniff {
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -22,11 +25,11 @@ class Vanilla_Sniffs_Methods_MethodCallFormattingSniff implements PHP_CodeSniffe
 
 
     /**
-     * @param PHP_CodeSniffer_File $phpcsFile
+     * @param File $phpcsFile
      * @param int $stackPtr
      * @return null
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+    public function process(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
 
         $pointer = $stackPtr + 1;

--- a/code-sniffer/Vanilla/Sniffs/NamingConventions/ValidClassBracketsSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/NamingConventions/ValidClassBracketsSniff.php
@@ -15,11 +15,14 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
  * Ensures curly brackets are on the same line as the Class declaration
  *
  */
-class Vanilla_Sniffs_NamingConventions_ValidClassBracketsSniff implements PHP_CodeSniffer_Sniff {
+class Vanilla_Sniffs_NamingConventions_ValidClassBracketsSniff implements Sniff {
 
 /**
  * Returns an array of tokens this test wants to listen for.
@@ -33,11 +36,11 @@ class Vanilla_Sniffs_NamingConventions_ValidClassBracketsSniff implements PHP_Co
 /**
  * Processes this test, when one of its tokens is encountered.
  *
- * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+ * @param File $phpcsFile The file being scanned.
  * @param integer $stackPtr  The position of the current token in the stack passed in $tokens.
  * @return void
  */
-	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+	public function process(File $phpcsFile, $stackPtr) {
 		$tokens = $phpcsFile->getTokens();
 
 		$found = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, $stackPtr);


### PR DESCRIPTION
The current CodeSniffer classes are setup to work with v2. This update makes them work with v3. It was mostly shifting from long-form classnames to namespaced classes. Rigorous testing has not been performed, but the "sniffs" seem to mostly work as expected in IDE integration.