### PR TITLE
Relax standards for file, class and function comments

### DIFF
--- a/code-sniffer/Vanilla/Sniffs/Commenting/ClassCommentSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Commenting/ClassCommentSniff.php
@@ -16,10 +16,6 @@ use PHP_CodeSniffer\Util\Tokens;
  * Verifies that :
  * <ul>
  *  <li>A class doc comment exists.</li>
- *  <li>There is exactly one blank line before the class comment.</li>
- *  <li>Short description ends with a full stop.</li>
- *  <li>Long description ends with a full stop.</li>
- *  <li>There is a blank line between the description and the tags.</li>
  * </ul>
  */
 class Vanilla_Sniffs_Commenting_ClassCommentSniff implements Sniff {
@@ -34,7 +30,7 @@ class Vanilla_Sniffs_Commenting_ClassCommentSniff implements Sniff {
             T_CLASS,
             T_INTERFACE
         );
-    }//end register()
+    }
 
 
     /**
@@ -46,19 +42,10 @@ class Vanilla_Sniffs_Commenting_ClassCommentSniff implements Sniff {
      * @return void
      */
     public function process(File $phpcsFile, $stackPtr) {
-        $this->currentFile = $phpcsFile;
-
         $tokens    = $phpcsFile->getTokens();
-        $type      = strtolower($tokens[$stackPtr]['content']);
-        $errorData = array($type);
 
         $find   = Tokens::$methodPrefixes;
         $find[] = T_WHITESPACE;
-
-        $empty = array(
-            T_DOC_COMMENT_WHITESPACE,
-            T_DOC_COMMENT_STAR,
-        );
 
         $commentEnd = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
         if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
@@ -87,115 +74,5 @@ class Vanilla_Sniffs_Commenting_ClassCommentSniff implements Sniff {
                 return;
             }
         }
-
-        // The first line of the comment should just be the /** code.
-        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
-            $phpcsFile->addError('You must use "/**" style comments for a class comment', $stackPtr, 'WrongStyle');
-            return;
-        }
-        $commentStart = $tokens[$commentEnd]['comment_opener'];
-
-        // The last line of the comment should just be the */ code.
-        $prev = $phpcsFile->findPrevious($empty, ($commentEnd - 1), $commentStart, true);
-        if ($tokens[$prev]['line'] === $tokens[$commentEnd]['line']) {
-            $phpcsFile->addError('The close comment tag must be the only content on the line', $commentStart, 'WrongStyle');
-            return;
-        }
-
-        $short = $phpcsFile->findNext($empty, ($commentStart + 1), $commentEnd, true);
-
-        // Check that a short description exists
-        if ($short === false) {
-            $error = 'Missing short description in class doc comment';
-            $phpcsFile->addError($error, $commentStart, 'MissingShort');
-            return;
-        }
-
-        // No extra newline before short description.
-        if ($tokens[$short]['line'] !== $tokens[$commentStart]['line'] + 1) {
-            $error = 'Doc comment short description must be on the first line';
-            $phpcsFile->addError($error, ($commentStart + 1), 'SpacingBeforeShort');
-        }
-
-        // Short desc must be single line.
-        $shortEnd = $short;
-        $isShortSingleLine = true;
-        for ($i = ($short + 1); $i < $commentEnd; $i++) {
-            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                if ($tokens[$i]['line'] === ($tokens[$shortEnd]['line'] + 1)) {
-                    $error = 'Class comment short description must be on a single line';
-                    $phpcsFile->addError($error, ($commentStart + 1), 'ShortSingleLine');
-                    $isShortSingleLine = false;
-                }
-                break;
-            }
-        }
-
-        $shortContent = $tokens[$short]['content'];
-        // Short desc start with capital letter
-        if (preg_match('/^\p{Ll}/u', $shortContent) === 1) {
-            $error = 'Doc comment short description must start with a capital letter';
-            $phpcsFile->addError($error, $short, 'ShortNotCapital');
-        }
-
-        // Short desc must end with a full stop
-        if ($isShortSingleLine && substr($shortContent, -1) !== '.') {
-            $error = 'Short description must end with a full stop';
-            $phpcsFile->addError($error, $commentStart, 'MissingShortFullStop');
-        }
-
-        // Detect long description
-        $long = $phpcsFile->findNext($empty, ($shortEnd + 1), ($commentEnd - 1), true);
-        if ($long !== false) {
-            if ($tokens[$long]['code'] === T_DOC_COMMENT_STRING) {
-
-                // There must be a blank line before long desc and short desc
-                if ($tokens[$long]['line'] !== ($tokens[$shortEnd]['line'] + 2)) {
-                    $error = 'There must be exactly one blank line between descriptions in a doc comment';
-                }
-
-                // Long desc must start with a capital letter
-                if (preg_match('/^\p{Ll}/u', $tokens[$long]['content']) === 1) {
-                    $error = 'Doc comment long description must start with a capital letter';
-                    $phpcsFile->addError($error, $long, 'LongNotCapital');
-                }
-
-                // Account for the fact that a long description might cover
-                // multiple lines.
-                $longContent = $tokens[$short]['content'];
-                $longEnd     = $long;
-                for ($i = ($long + 1); $i < $commentEnd; $i++) {
-                    if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                        if ($tokens[$i]['line'] === ($tokens[$longEnd]['line'] + 1)) {
-                            $longContent .= $tokens[$i]['content'];
-                            $longEnd      = $i;
-                        } else {
-                            break;
-                        }
-                    }
-                }
-
-                // Long desc must end with a full stop
-                if (substr($longContent, -1) !== '.') {
-                    $error = 'Long description must end with a full stop';
-                    $phpcsFile->addError($error, $commentStart, 'MissingLongFullStop');
-                }
-            }//end if
-        }
-
-        // No tags are allowed in the class comment.
-        if (empty($tokens[$commentStart]['comment_tags']) === false) {
-            $firstTag = $tokens[$tokens[$commentStart]['comment_tags'][0]]['content'];
-            $error = '%s tag is not allowed in class comment';
-            $phpcsFile->addWarning($error, $tokens[$commentStart]['comment_tags'][0], 'TagNotAllowed', $firstTag);
-        }
-
-        // There should be no blank line before the comment ending
-        $lastCommentString = $phpcsFile->findPrevious($empty, $commentEnd - 1, $commentStart, true);
-        if ($tokens[$commentEnd]['line'] - 1 !== $tokens[$lastCommentString]['line']) {
-            $error = 'Additional blank lines found at end of class comment';
-            $this->currentFile->addError($error, $commentEnd, 'SpacingAfter');
-        }
-
     }
 }

--- a/code-sniffer/Vanilla/Sniffs/Commenting/FileCommentSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Commenting/FileCommentSniff.php
@@ -61,24 +61,16 @@ class Vanilla_Sniffs_Commenting_FileCommentSniff implements Sniff {
     public function register() {
         return array(T_OPEN_TAG);
 
-    }//end register()
-
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
      *
      * @param File $phpcsFile The file being scanned.
      * @param int $stackPtr  The position of the current token in the stack passed in $tokens.
-     *
-     * @return int
      */
     public function process(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
-
-        $empty = array(
-            T_DOC_COMMENT_WHITESPACE,
-            T_DOC_COMMENT_STAR,
-        );
 
         // Find the next non whitespace token.
         $commentStart = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
@@ -113,183 +105,6 @@ class Vanilla_Sniffs_Commenting_FileCommentSniff implements Sniff {
         if ($tokens[$nextNonWhitespace]['line'] - 2 !== $tokens[$commentEnd]['line']) {
             $error = 'There must be exactly one blank line after the file comment';
             $phpcsFile->addError($error, ($commentEnd + 1), 'SpacingAfterComment');
-        }
-
-        // Check that a description exists
-        $description = $phpcsFile->findNext($empty, ($commentStart + 1), $commentEnd, true);
-        if ($description === false) {
-            $error = 'Missing description in file doc comment';
-            $phpcsFile->addError($error, $commentStart, 'MissingShort');
-            return;
-        }
-
-        // Check each tag.
-        $this->processTags($phpcsFile, $stackPtr, $commentStart);
-
-        // Ignore the rest of the file.
-        return;
-
-    }//end process()
-
-
-    /**
-     * Processes each required or optional tag.
-     *
-     * @param File $phpcsFile The file being scanned.
-     * @param int $stackPtr The position of the current token in the stack passed in $tokens.
-     * @param int $commentStart Position in the stack where the comment started.
-     *
-     * @return void
-     */
-    protected function processTags(File $phpcsFile, $stackPtr, $commentStart) {
-        $tokens = $phpcsFile->getTokens();
-
-        if (get_class($this) === 'PEAR_Sniffs_Commenting_FileCommentSniff') {
-            $docBlock = 'file';
-        } else {
-            $docBlock = 'class';
-        }
-
-        $commentEnd = $tokens[$commentStart]['comment_closer'];
-
-        $foundTags = array();
-        $tagTokens = array();
-        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
-            $name = $tokens[$tag]['content'];
-            if (isset($this->tags[$name]) === false) {
-                continue;
-            }
-
-            if ($this->tags[$name]['allow_multiple'] === false && isset($tagTokens[$name]) === true) {
-                $error = 'Only one %s tag is allowed in a %s comment';
-                $data  = array(
-                    $name,
-                    $docBlock,
-                );
-                $phpcsFile->addError($error, $tag, 'Duplicate'.ucfirst(substr($name, 1)).'Tag', $data);
-            }
-
-            $foundTags[]        = $name;
-            $tagTokens[$name][] = $tag;
-
-            $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $tag, $commentEnd);
-            if ($string === false || $tokens[$string]['line'] !== $tokens[$tag]['line']) {
-                $error = 'Content missing for %s tag in %s comment';
-                $data  = array(
-                    $name,
-                    $docBlock,
-                );
-                $phpcsFile->addError($error, $tag, 'Empty'.ucfirst(substr($name, 1)).'Tag', $data);
-                continue;
-            }
-        }//end foreach
-
-        // Check if the tags are in the correct position.
-        $pos = 0;
-        foreach ($this->tags as $tag => $tagData) {
-            if (isset($tagTokens[$tag]) === false) {
-                if ($tagData['required'] === true) {
-                    $error = 'Missing %s tag in %s comment';
-                    $data  = array(
-                        $tag,
-                        $docBlock,
-                    );
-                    $phpcsFile->addError($error, $commentEnd, 'Missing'.ucfirst(substr($tag, 1)).'Tag', $data);
-                }
-
-                continue;
-            } else {
-                $method = 'process'.substr($tag, 1);
-                if (method_exists($this, $method) === true) {
-                    // Process each tag if a method is defined.
-                    call_user_func(array($this, $method), $phpcsFile, $tagTokens[$tag]);
-                }
-            }
-
-            if (isset($foundTags[$pos]) === false) {
-                break;
-            }
-
-            if ($foundTags[$pos] !== $tag) {
-                $error = 'The tag in position %s should be the %s tag';
-                $data  = array(
-                    ($pos + 1),
-                    $tag,
-                );
-                $phpcsFile->addError($error, $tokens[$commentStart]['comment_tags'][$pos], ucfirst(substr($tag, 1)).'TagOrder', $data);
-            }
-
-            // Account for multiple tags.
-            $pos++;
-            while (isset($foundTags[$pos]) === true && $foundTags[$pos] === $tag) {
-                $pos++;
-            }
-        }//end foreach
-
-    }//end processTags()
-
-    /**
-     * Process the copyright tags.
-     *
-     * @param File $phpcsFile The file being scanned.
-     * @param array $tags The tokens for these tags.
-     *
-     * @return void
-     */
-    protected function processCopyright(File $phpcsFile, array $tags) {
-        $vanillaFound = false;
-        $tokens = $phpcsFile->getTokens();
-        foreach ($tags as $tag) {
-            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
-                // No content.
-                continue;
-            }
-
-            $content = $tokens[($tag + 2)]['content'];
-            $matches = array();
-
-            if (empty($content) === true) {
-                $error = 'Content missing for @copyright tag in file comment';
-                $phpcsFile->addError($error, $tag, 'MissingCopyright');
-            }
-
-            date_default_timezone_set('UTC');
-            preg_match('/^2009\-(\d{4}) Vanilla Forums Inc./', $content, $matches);
-            if (!empty($matches) && $matches[1] == date('Y', time())) {
-                $vanillaFound = true;
-            }
-        }//end foreach
-
-        if (!$vanillaFound) {
-            $error = 'Expected "2009-' . date('Y') . ' Vanilla Forums Inc." for copyright declaration';
-            $phpcsFile->addError($error, $tag, 'IncorrectCopyright');
-        }
-
-    }//end processCopyright()
-
-    /**
-     * Process the license tag.
-     *
-     * @param File $phpcsFile The file being scanned.
-     * @param array $tags The tokens for these tags.
-     *
-     * @return void
-     */
-    protected function processLicense(File $phpcsFile, array $tags) {
-        $tokens = $phpcsFile->getTokens();
-        foreach ($tags as $tag) {
-            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
-                // No content.
-                continue;
-            }
-
-            $content = $tokens[($tag + 2)]['content'];
-            $matches = array();
-            preg_match('/^([^\s]+)\s+(.*)/', $content, $matches);
-            if (count($matches) !== 3) {
-                $error = '@license tag must contain a URL and a license name';
-                $phpcsFile->addError($error, $tag, 'IncompleteLicense');
-            }
         }
     }
 }

--- a/code-sniffer/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -37,7 +37,7 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements Sniff {
     public function register() {
         return array(T_FUNCTION);
 
-    }//end register()
+    }
 
 
     /**
@@ -103,52 +103,11 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements Sniff {
             $phpcsFile->addError($error, ($commentStart + 1), 'SpacingBeforeShort');
         }
 
-        // Short desc must be single line. (Also cover long desc new line before)
-        $shortEnd = $short;
-        for ($i = ($short + 1); $i < $commentEnd; $i++) {
-            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                if ($tokens[$i]['line'] === ($tokens[$shortEnd]['line'] + 1)) {
-                    $error = 'Class comment short description must be on a single line';
-                    $phpcsFile->addError($error, ($commentStart + 1), 'ShortSingleLine');
-                }
-                break;
-            }
-        }
-
         $shortContent = $tokens[$short]['content'];
         // Short desc start with capital letter
         if (preg_match('#^(\p{Lu}|\P{L})#u', $shortContent) === 0) {
             $error = 'Doc comment short description must start with a capital letter';
             $phpcsFile->addError($error, $short, 'ShortNotCapital');
-        }
-
-        // Detect long description
-        $long = $phpcsFile->findNext($empty, ($shortEnd + 1), ($commentEnd - 1), true);
-        if ($long !== false) {
-            if ($tokens[$long]['code'] === T_DOC_COMMENT_STRING) {
-
-                // Long desc must start with a capital letter
-                if (preg_match('/^(\p{Lu}|\P{L})/u', $tokens[$long]['content'][0]) === 0) {
-                    $error = 'Doc comment long description must start with a capital letter';
-                    $phpcsFile->addError($error, $long, 'LongNotCapital');
-                }
-
-                // Account for the fact that a long description might cover
-                // multiple lines.
-                $longContent = $tokens[$short]['content'];
-                $longEnd     = $long;
-                for ($i = ($long + 1); $i < $commentEnd; $i++) {
-                    if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                        if ($tokens[$i]['line'] === ($tokens[$longEnd]['line'] + 1)) {
-                            $longContent .= $tokens[$i]['content'];
-                            $longEnd      = $i;
-                        } else {
-                            break;
-                        }
-                    }
-                }
-
-            }//end if
         }
 
         // Ignore blocks with inheritdoc tags
@@ -262,13 +221,8 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements Sniff {
                 $error = 'Return type missing for @return tag in function comment';
                 $phpcsFile->addError($error, $return, 'MissingReturnType');
             }
-        } else {
-            $error = 'Missing @return tag in function comment';
-            $phpcsFile->addError($error, $tokens[$commentStart]['comment_closer'], 'MissingReturn');
-        }//end if
-
+        }
     }//end processReturn()
-
 
     /**
      * Process any throw tags that this function comment has.
@@ -395,9 +349,6 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements Sniff {
                                 $comment .= ' '.$tokens[$i]['content'];
                             }
                         }
-                    } else {
-                        $error = 'Missing parameter comment';
-                        $phpcsFile->addError($error, $tag, 'MissingParamComment');
                     }
                 } else {
                     $error = 'Missing parameter name';


### PR DESCRIPTION
The rules for comments are a bit contradictory, depending on where you look and what is enforced by CodeSniffer. In the interest of simplifying things, this update greatly relaxes the commenting "sniffs" used by CodeSniffer. Classes and files just need a doc block. Functions also need a doc block, but parameters must also be documented, although their specifics have also been relaxed.

Closes #17