### PR TITLE
Handle inherit doc when sniffing function doc blocks

### DIFF
--- a/code-sniffer/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -288,12 +288,16 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements Sniff {
      */
     protected function processParams(File $phpcsFile, $stackPtr, $commentStart) {
         $tokens = $phpcsFile->getTokens();
+        $hasInheritDoc = false;
 
         // Validate params structure
         $params  = array();
         $maxType = 0;
         $maxVar  = 0;
         foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
+            if ($tokens[$tag]['content'] === "@inheritdoc") {
+                $hasInheritDoc = true;
+            }
             if ($tokens[$tag]['content'] !== '@param') {
                 continue;
             }
@@ -446,11 +450,13 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements Sniff {
         }
 
         // Report missing comments.
-        $diff = array_diff($realNames, $foundParams);
-        foreach ($diff as $neededParam) {
-            $error = 'Doc comment for parameter "%s" missing';
-            $data  = array($neededParam);
-            $phpcsFile->addError($error, $commentStart, 'MissingParamTag', $data);
+        if (!$hasInheritDoc) {
+            $diff = array_diff($realNames, $foundParams);
+            foreach ($diff as $neededParam) {
+                $error = 'Doc comment for parameter "%s" missing';
+                $data  = array($neededParam);
+                $phpcsFile->addError($error, $commentStart, 'MissingParamTag', $data);
+            }
         }
     }
 }


### PR DESCRIPTION
It seems we did go with the acceptance criteria of https://github.com/vanilla/standards/issues/17 at all. Since we don't seem to care to do that, I'm submitting this PR instead.

## Changes

Loosens the method sniffing to:
- Suppress errors about about missing `@param`  tags when an `@inheritdoc` comment is present.

This way we do not need to redefine the param descriptions every time we extend a parent class.