### PR TITLE
Add additional vanilla method naming exceptions

### DIFF
--- a/code-sniffer/Vanilla/Sniffs/Methods/CamelCapsMethodNameSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Methods/CamelCapsMethodNameSniff.php
@@ -102,7 +102,15 @@ class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends AbstractScopeSniff
             '_before',
             '_override',
             '_after',
-            'controller_'
+            'controller_',
+            'get_',
+            'post_',
+            'patch_',
+            'post_',
+            'index_',
+            'put_',
+            'options_',
+            'delete_',
         );
         foreach ($patterns as $pattern) {
             if (stristr($name, $pattern) !== false) {

--- a/code-sniffer/Vanilla/Sniffs/Methods/CamelCapsMethodNameSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Methods/CamelCapsMethodNameSniff.php
@@ -104,7 +104,6 @@ class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends AbstractScopeSniff
             '_after',
             'controller_',
             'get_',
-            'post_',
             'patch_',
             'post_',
             'index_',


### PR DESCRIPTION
Adds additional exceptions to our method name sniff to align with how we name our API controllers.