### PR TITLE
Add method naming exeption for _init

### DIFF
--- a/code-sniffer/Vanilla/Sniffs/Methods/CamelCapsMethodNameSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Methods/CamelCapsMethodNameSniff.php
@@ -102,6 +102,7 @@ class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends AbstractScopeSniff
             '_before',
             '_override',
             '_after',
+            '_init',
             'controller_',
             'get_',
             'patch_',


### PR DESCRIPTION
Adds an exception for method ending in `_init`. The `container_init` event needs to be allowed to have handlers.

Additionally we have the

- `schema_init` (used on many api endpoints). ex. `userIndexSchema_init`
- `curl_init`
