### PR TITLE
Relax the @inheritdoc code sniff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ nbproject/project.xml
 /build/*
 !/build/build.xml
 !/build/package-contents.txt
+composer.lock

--- a/code-sniffer/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/code-sniffer/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -116,7 +116,7 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements Sniff {
             $docCommentContent .= $tokens[$i]['content'];
         }
 
-        if (stristr($docCommentContent, '{@inheritdoc}') !== false) {
+        if (stristr($docCommentContent, '@inheritdoc') !== false) {
             return;
         }
 


### PR DESCRIPTION
It seems as though a doc comment of just `@inheritdoc` is now acceptable and inserted with PhpStorm.